### PR TITLE
Enhance UX with testimonials, theme toggle and navigation aids

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,6 +101,7 @@
   </noscript>
 
   <!-- App Container -->
+  <a href="#main" class="sr-only focus:not-sr-only absolute top-2 left-2 bg-blue-600 text-white px-4 py-2 rounded z-50">Skip to content</a>
   <div id="root"></div>
 
   <!-- Main Script Bundle -->

--- a/src/HomePage.jsx
+++ b/src/HomePage.jsx
@@ -1,52 +1,29 @@
-import React, { useState } from "react";
+import React from "react";
 import { motion } from "framer-motion";
 import Header from "./components/sections/Header";
 import Hero from "./components/sections/Hero";
 import Services from "./components/sections/Service";
 import About from "./components/sections/About";
 import Projects from "./components/sections/Project";
+import Testimonials from "./components/sections/Testimonials";
 import Bookings from "./components/sections/Booking";
 import Contact from "./components/sections/Contact";
+import BackToTop from "./components/sections/BackToTop";
 
 export default function HomePage() {
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-
-  const fadeInUp = {
-    hidden: { opacity: 0, y: 20 },
-    visible: { opacity: 1, y: 0 }
-  };
-
-  const staggerContainer = {
-    hidden: { opacity: 0 },
-    visible: {
-      opacity: 1,
-      transition: {
-        staggerChildren: 0.1
-      }
-    }
-  };
-
   return (
-    <div className="font-sans text-gray-800 bg-white">
-      {/* Header */}
-      {/* Hero */}
-      {/* Services */}
-      {/* Projects */}
-      {/* Booking Section */}
-      {/* Contact */}
-      {/* Footer */}
+    <div className="font-sans text-gray-800 bg-white relative">
       <Header />
-      <Hero />
-      <Services />
-      <About />
-      <Projects />
-      <Bookings />
-      <Contact />
-
-
-
-      {/* Footer */}
-      <motion.footer 
+      <main id="main">
+        <Hero />
+        <Services />
+        <About />
+        <Projects />
+        <Testimonials />
+        <Bookings />
+        <Contact />
+      </main>
+      <motion.footer
         initial={{ opacity: 0 }}
         whileInView={{ opacity: 1 }}
         viewport={{ once: true }}
@@ -55,12 +32,19 @@ export default function HomePage() {
         <div className="max-w-6xl mx-auto px-6">
           <p>© {new Date().getFullYear()} Diffrenzz. All rights reserved.</p>
           <div className="mt-2 flex justify-center space-x-4">
-            <a href="/privacy-policy.html" className="hover:text-gray-700">Privacy Policy</a>
-            <a href="/cookie-policy.html" className="hover:text-gray-700">Cookie Policy</a>
-            <a href="/terms-of-service.html" className="hover:text-gray-700">Terms of Service</a>
+            <a href="/privacy-policy.html" className="hover:text-gray-700">
+              Privacy Policy
+            </a>
+            <a href="/cookie-policy.html" className="hover:text-gray-700">
+              Cookie Policy
+            </a>
+            <a href="/terms-of-service.html" className="hover:text-gray-700">
+              Terms of Service
+            </a>
           </div>
         </div>
       </motion.footer>
+      <BackToTop />
     </div>
   );
 }

--- a/src/components/sections/BackToTop.jsx
+++ b/src/components/sections/BackToTop.jsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import { ArrowUpIcon } from '@heroicons/react/24/outline';
+
+const BackToTop = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => {
+      setVisible(window.scrollY > 300);
+    };
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const scrollTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return (
+    <button
+      aria-label="Back to top"
+      onClick={scrollTop}
+      className={`fixed bottom-5 right-5 p-3 rounded-full bg-blue-600 text-white shadow-lg transition-opacity ${
+        visible ? 'opacity-100' : 'opacity-0 pointer-events-none'
+      }`}
+    >
+      <ArrowUpIcon className="w-5 h-5" />
+    </button>
+  );
+};
+
+export default BackToTop;

--- a/src/components/sections/Header.jsx
+++ b/src/components/sections/Header.jsx
@@ -1,10 +1,25 @@
 import { motion, useScroll, useSpring, useMotionValueEvent } from "framer-motion";
-import { useState } from "react";
-import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/outline";
+import { useState, useEffect } from "react";
+import { Bars3Icon, XMarkIcon, SunIcon, MoonIcon } from "@heroicons/react/24/outline";
 
 const Header = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
+  const [theme, setTheme] = useState(() =>
+    localStorage.getItem('theme') || 'dark'
+  );
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    const body = document.body;
+    body.classList.remove('bg-gray-900', 'text-gray-100', 'bg-white', 'text-gray-900');
+    if (theme === 'dark') {
+      body.classList.add('bg-gray-900', 'text-gray-100');
+    } else {
+      body.classList.add('bg-white', 'text-gray-900');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
 
   // Get both scrollY and scrollYProgress
   const { scrollY, scrollYProgress } = useScroll();
@@ -96,6 +111,18 @@ const Header = () => {
               ))}
             </nav>
 
+            <button
+              onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+              aria-label="Toggle theme"
+              className="hidden md:block p-2 rounded-md text-gray-700 hover:bg-gray-100"
+            >
+              {theme === 'dark' ? (
+                <SunIcon className="w-6 h-6" />
+              ) : (
+                <MoonIcon className="w-6 h-6" />
+              )}
+            </button>
+
             <motion.button
               whileTap={{ scale: 0.95 }}
               className="md:hidden p-2 rounded-md focus:outline-none text-gray-700"
@@ -136,6 +163,20 @@ const Header = () => {
               {item.name}
             </motion.a>
           ))}
+          <button
+            onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+            className="mt-2 p-2 rounded-md bg-gray-100 flex items-center space-x-2"
+          >
+            {theme === 'dark' ? (
+              <>
+                <SunIcon className="w-5 h-5" /> <span>Light mode</span>
+              </>
+            ) : (
+              <>
+                <MoonIcon className="w-5 h-5" /> <span>Dark mode</span>
+              </>
+            )}
+          </button>
         </div>
       </motion.div>
     </>

--- a/src/components/sections/Hero.jsx
+++ b/src/components/sections/Hero.jsx
@@ -112,7 +112,7 @@ const Hero = () => {
           style={{ scale: titleScale }}
           className="text-4xl md:text-6xl lg:text-7xl font-bold mb-6 text-white leading-tight will-change-transform"
         >
-          Smart <span className="text-yellow-300">Salesforce</span> Solutions
+          <span className="typewriter">Smart Salesforce Solutions</span>
         </motion.h1>
 
         <motion.p

--- a/src/components/sections/Testimonials.jsx
+++ b/src/components/sections/Testimonials.jsx
@@ -1,0 +1,78 @@
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Pagination, Autoplay } from 'swiper/modules';
+import { motion } from 'framer-motion';
+import 'swiper/css';
+import 'swiper/css/pagination';
+
+const testimonials = [
+  {
+    name: 'Acme Corp',
+    role: 'Operations Lead',
+    feedback:
+      'Diffrenzz transformed our Salesforce setup and automated key processes. Productivity has never been higher.',
+    avatar:
+      'https://images.unsplash.com/photo-1502685104226-ee32379fefbe?auto=format&fit=crop&w=80&q=80'
+  },
+  {
+    name: 'Globex Inc.',
+    role: 'CTO',
+    feedback:
+      'Their expertise helped us integrate multiple systems seamlessly. The results were immediate and impressive.',
+    avatar:
+      'https://images.unsplash.com/photo-1544723495-432537d1f88f?auto=format&fit=crop&w=80&q=80'
+  },
+  {
+    name: 'Nonprofit XYZ',
+    role: 'Director',
+    feedback:
+      'Thanks to Diffrenzz we can manage donors twice as efficiently. Great communication and results.',
+    avatar:
+      'https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?auto=format&fit=crop&w=80&q=80'
+  }
+];
+
+const Testimonials = () => {
+  return (
+    <section id="testimonials" className="py-20 px-6 bg-white">
+      <div className="max-w-5xl mx-auto">
+        <h2 className="text-3xl md:text-4xl font-bold text-center mb-8">
+          Client <span className="text-blue-600">Testimonials</span>
+        </h2>
+        <Swiper
+          modules={[Pagination, Autoplay]}
+          spaceBetween={30}
+          slidesPerView={1}
+          loop
+          autoplay={{ delay: 5000 }}
+          pagination={{ clickable: true }}
+        >
+          {testimonials.map((t, i) => (
+            <SwiperSlide key={i}>
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                className="bg-gray-50 rounded-xl p-8 shadow-md"
+              >
+                <div className="flex items-center mb-4">
+                  <img
+                    src={t.avatar}
+                    alt={t.name}
+                    className="w-12 h-12 rounded-full mr-3"
+                  />
+                  <div>
+                    <p className="font-semibold">{t.name}</p>
+                    <p className="text-sm text-gray-500">{t.role}</p>
+                  </div>
+                </div>
+                <p className="text-gray-700 leading-relaxed">{t.feedback}</p>
+              </motion.div>
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      </div>
+    </section>
+  );
+};
+
+export default Testimonials;

--- a/src/index.css
+++ b/src/index.css
@@ -40,3 +40,26 @@ html {
     transition: none;
   }
 }
+
+/* Typewriter animation for hero title */
+@keyframes typing {
+  from {
+    width: 0;
+  }
+  to {
+    width: 100%;
+  }
+}
+
+@keyframes blink {
+  50% {
+    border-color: transparent;
+  }
+}
+
+.typewriter {
+  overflow: hidden;
+  white-space: nowrap;
+  border-right: 2px solid currentColor;
+  animation: typing 3s steps(30, end), blink 0.75s step-end infinite;
+}


### PR DESCRIPTION
## Summary
- add skip link to jump directly to main content
- implement theme switcher with persistence
- build new testimonial slider using Swiper
- animate hero title with a typewriter effect
- provide back‑to‑top button for easier navigation

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6855874feed08326aa67c6cd46b3c2bc